### PR TITLE
Update dependancies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/Yuuki-Discord/commandrb.git
-  revision: 3c18c1028ddce3755d6491610deddbed2fda4516
+  revision: 477e7499119eee92b209e7b5b415e662eb1dcb3c
   specs:
     commandrb (0.4.7.2)
       discordrb (~> 3.1, >= 3.1.0)
 
 GIT
   remote: https://github.com/discordrb/discordrb.git
-  revision: 44f93948a812e06b439968c6b072c0d9b749a842
+  revision: b739895505aac8bf6d0cbbda98ade1600e660abb
   specs:
     discordrb (3.3.0)
       discordrb-webhooks (~> 3.3.0)
@@ -16,20 +16,20 @@ GIT
       rest-client (>= 2.0.0)
       websocket-client-simple (>= 0.3.0)
     discordrb-webhooks (3.3.0)
-      rest-client (>= 2.1.0.rc1)
+      rest-client (>= 2.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     chunky_png (1.3.11)
-    coderay (1.1.2)
+    coderay (1.1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.6)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.2)
-    ffi (1.12.2-x64-mingw32)
+    ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
     haste (0.2.3)
       faraday (~> 0.9)
       json
@@ -40,7 +40,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
+    mime-types-data (3.2020.0512)
     multipart-post (2.1.1)
     netrc (0.11.0)
     opus-ruby (1.0.1)
@@ -50,7 +50,7 @@ GEM
       method_source (~> 1.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    redis (4.1.3)
+    redis (4.2.1)
     redis-namespace (1.7.0)
       redis (>= 3.0.4)
     rest-client (2.1.0)
@@ -72,7 +72,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unf_ext (0.0.7.7-x64-mingw32)
     websocket (1.2.8)
     websocket-client-simple (0.3.0)
       event_emitter


### PR DESCRIPTION
Ones not mentioned remained the same:
```
Using discordrb 3.3.0 from https://github.com/discordrb/discordrb.git (at master@b739895)
Using commandrb 0.4.7.2 from https://github.com/Yuuki-Discord/commandrb.git (at master@477e749)
Using coderay 1.1.3 (was 1.1.2)
Using mime-types-data 3.2020.0512 (was 3.2019.1009)
Using ffi 1.13.1 (was 1.12.2)
Using redis 4.2.1 (was 4.1.3)
```
