### PR TITLE
Rubocop: remove unneeded exclusion for Style/GlobalVars

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,10 +29,6 @@ Layout/LineLength:
     - "config/custom/custom.sample.rb"
   Max: 100
 
-Style/GlobalVars:
-  Exclude:
-    - "run.rb"
-
 Security/Open:
   Exclude:
     - "modules/helper/download.rb"


### PR DESCRIPTION
Not sure why this was here, maybe something to do with the old `$cbot` that got replaced with `YuukiBot.crb`? Nothing fails if I remove it so might as well.