### PR TITLE
devcontainer: Migrate to Debian

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN bundle config --global frozen 1
 
 WORKDIR /workspace
 
-RUN apt update && apt install -y --no-install-recommends git build-essential redis-tools
+RUN apt update && apt install -y --no-install-recommends git build-essential redis-tools openssh-client
 RUN echo "alias redis-cli='redis-cli -h redis'" > /root/.bashrc
 
 CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
-FROM ruby:2.7-alpine
+FROM ruby:2.7-buster
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1
 
 WORKDIR /workspace
 
-RUN apk update && apk add git build-base redis bash
+RUN apt update && apt install -y --no-install-recommends git build-essential redis-tools
 RUN echo "alias redis-cli='redis-cli -h redis'" > /root/.bashrc
 
 CMD ["sleep", "infinity"]

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: RuboCop Linter Action
-        uses: andrewmcodes/rubocop-linter-action@v3.2.0
+        uses: andrewmcodes/rubocop-linter-action@v3.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
While it works fine in VSCode, GitHub Codespaces doesn't support Alpine. How sad.

Hopefully someday this can be reverted!