### PR TITLE
Migrate to v2 of docker build/push action

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -1,13 +1,11 @@
-name: Docker test build (Devcontainer)
+name: Build and deploy Docker image
 
 on:
   push:
-    branches: "*"
-  pull_request:
-    branches: "*"
+    branches: master
 
 jobs:
-  test-build-prod:
+  docker-deploy:
     runs-on: ubuntu-latest
     steps:
       -
@@ -20,12 +18,18 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
-        name: Build image
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: ./.devcontainer/Dockerfile
+          file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: true
           tags: |
             yuukibot/yuukichan:latest

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -7,7 +7,7 @@ on:
     branches: "*"
 
 jobs:
-  test-build-prod:
+  test-build-dev:
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -2,26 +2,30 @@ name: Docker test build
 
 on:
   push:
-    branches: 
-    - '*'
-
+    branches: "*"
   pull_request:
-    branches: 
-    - '*'
+    branches: "*"
 
 jobs:
   test-build-prod:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
+      -
+        name: Checkout
         uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build image
+        uses: docker/build-push-action@v2
         with:
-          fetch-depth: 0
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v1
-        with:
-          repository: yuukibot/yuukichan
-          tag_with_ref: true
-          add_git_labels: true
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: false
+          tags: |
+            yuukibot/yuukichan:latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -7,7 +7,7 @@ on:
     branches: "*"
 
 jobs:
-  test-build-dev:
+  test-build-prod:
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -7,7 +7,7 @@ on:
     branches: "*"
 
 jobs:
-  test-build-prod:
+  test-build-dev:
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
This is the PR that I originally wanted to make today, before RuboCop 1.0 said hello. Make sure to merge that one beforehand, since this modifies checks and might get messy.

These changes upgrade to v2 of the Docker GitHub Action. 
But that's not all! The new action makes use of `docker buildx`, most notably meaning we can now build images for multiple architectures simultaneously.

As such, this PR officially adds support for the `linux/arm64` Docker platform.
Unfortunately we can't easily target `linux/arm/v7` or `linux/arm/v6` because the `ruby:2.7-alpine` base image doesn't have support for those (For some reason? 3.0 rc does, not sure what's up there)

Also, in order to achieve this, we're moving (back!) to GitHub Actions for publishing the image to Docker Hub. Simply because it's easier to do, and works nicely with ARM64 images.