### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Lets not bake stray data into an image by mistake.
-data/redis/*
+data/redis/appendonly.aof
+data/redis/dump.rdb
 
 # While we do want all the sample configs (for processing),
 #  we definitely do not want actual config files to end up in images 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Lets not bake stray data into an image by mistake.
+data/redis/*
+
+# While we do want all the sample configs (for processing),
+#  we definitely do not want actual config files to end up in images 
+config/config.yml
+config/custom/custom.rb
+config/custom/custom.yml


### PR DESCRIPTION
Similar to a `.gitignore` file, ` .dockerignore` prevents unwanted files (Data, configs) from ending up accidentally baked into Docker images!