### PR TITLE
Migrate to Ruby 3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-buster
+FROM ruby:3.0-buster
 
 WORKDIR /workspace
 

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
             yuukibot/yuukichan:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -2,7 +2,8 @@ name: Build and deploy Docker image
 
 on:
   push:
-    branches: master
+    branches: 
+      - master
 
 jobs:
   docker-deploy:
@@ -35,4 +36,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: |
-            yuukibot/yuukichan:latest
+            yuukibot/yuukichan:latest,

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -28,6 +28,19 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.CR_USERNAME }}
+          password: ${{ secrets.CR_PAT }}
+      -
         name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -37,3 +50,5 @@ jobs:
           push: true
           tags: |
             yuukibot/yuukichan:latest,
+            ghcr.io/yuuki-discord/yuuki-bot:latest,
+            docker.pkg.github.com/yuuki-discord/yuuki-bot/yuuki-bot:latest

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -2,9 +2,11 @@ name: Docker test build (Devcontainer)
 
 on:
   push:
-    branches: "*"
+    branches: 
+      - "*"
   pull_request:
-    branches: "*"
+    branches: 
+      - "*"
 
 jobs:
   test-build-dev:

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./.devcontainer/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: false
           tags: |
             yuukibot/yuukichan:latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -2,9 +2,11 @@ name: Docker test build
 
 on:
   push:
-    branches: "*"
+    branches: 
+      - "*"
   pull_request:
-    branches: "*"
+    branches: 
+      - "*"
 
 jobs:
   test-build-prod:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: false
           tags: |
             yuukibot/yuukichan:latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
     "recommendations": [
         "rebornix.ruby",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.0-alpine
 
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN bundle config --global frozen 1

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 source 'http://rubygems.org'
-gem 'commandrb', git: 'https://github.com/Yuuki-Discord/commandrb.git'
-gem 'discordrb', git: 'https://github.com/discordrb/discordrb.git'
+gem 'commandrb', github: 'Yuuki-Discord/commandrb'
+gem 'discordrb', github: 'shardlab/discordrb', branch: 'main'
 gem 'haste'
 
 gem 'rainbow'
 gem 'rake'
 gem 'redis'
-gem 'redis-namespace'
+gem 'redis-namespace', github: 'resque/redis-namespace',
+                       ref: 'c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e'
 gem 'rqrcode'
 gem 'rumoji'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,41 +6,50 @@ GIT
       discordrb (~> 3.1, >= 3.1.0)
 
 GIT
-  remote: https://github.com/discordrb/discordrb.git
-  revision: b739895505aac8bf6d0cbbda98ade1600e660abb
+  remote: https://github.com/resque/redis-namespace.git
+  revision: c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e
+  ref: c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e
   specs:
-    discordrb (3.3.0)
+    redis-namespace (1.8.0)
+      redis (>= 3.0.4)
+
+GIT
+  remote: https://github.com/shardlab/discordrb.git
+  revision: cec5d6854d786dafde25cbd604f52c6c5f452a26
+  branch: main
+  specs:
+    discordrb (3.4.0)
       discordrb-webhooks (~> 3.3.0)
       ffi (>= 1.9.24)
       opus-ruby
       rest-client (>= 2.0.0)
       websocket-client-simple (>= 0.3.0)
-    discordrb-webhooks (3.3.0)
-      rest-client (>= 2.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
     ast (2.4.1)
-    chunky_png (1.3.14)
+    chunky_png (1.3.15)
     coderay (1.1.3)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
     debase-ruby_core_source (0.10.11)
+    discordrb-webhooks (3.3.0)
+      rest-client (>= 2.1.0.rc1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.6)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     fastri (0.3.1.1)
-    ffi (1.13.1)
+    ffi (1.14.2)
     haste (0.2.3)
       faraday (~> 0.9)
       json
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    json (2.3.1)
+    json (2.5.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -50,29 +59,27 @@ GEM
     opus-ruby (1.0.1)
       ffi
     parallel (1.20.1)
-    parser (2.7.2.0)
+    parser (3.0.0.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rainbow (3.0.0)
-    rake (13.0.1)
+    rake (13.0.3)
     rcodetools (0.8.5.0)
     redis (4.2.5)
-    redis-namespace (1.8.0)
-      redis (>= 3.0.4)
-    regexp_parser (2.0.0)
+    regexp_parser (2.0.2)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.4)
-    rqrcode (1.1.2)
+    rqrcode (1.2.0)
       chunky_png (~> 1.0)
-      rqrcode_core (~> 0.1)
-    rqrcode_core (0.1.2)
-    rubocop (1.5.2)
+      rqrcode_core (~> 0.2)
+    rqrcode_core (0.2.0)
+    rubocop (1.7.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
@@ -93,7 +100,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
-    websocket (1.2.8)
+    websocket (1.2.9)
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
@@ -112,7 +119,7 @@ DEPENDENCIES
   rake
   rcodetools
   redis
-  redis-namespace
+  redis-namespace!
   rqrcode
   rubocop
   rubocop-rake
@@ -120,4 +127,4 @@ DEPENDENCIES
   rumoji
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.3'
 services: 
     yuuki:
         image: "yuukibot/yuukichan:latest"
+        # image: "ghcr.io/yuuki-discord/yuuki-bot"
         depends_on:
             - redis
         restart: on-failure

--- a/modules/utility/qr.rb
+++ b/modules/utility/qr.rb
@@ -4,6 +4,34 @@
 
 module YuukiBot
   module Utility
+    # Per https://git.io/JLMwW (rest-client@v2.1.0 lib/restclient/payload.rb#L48-L57),
+    # a file is any class responding to #path and #read. It additionally use basename.
+    # We use StringIO as a parent and implement path and others for File-like functionality.
+    class FauxFile < StringIO
+      @filename = ''
+      @filetype = ''
+
+      def initialize(contents, filename = 'unknown', filetype = 'application/octet-stream')
+        super contents
+
+        @filename = filename
+        @filetype = filetype
+      end
+
+      def path
+        @filename
+      end
+
+      # Path is assumed to only be the specified filename.
+      def original_filename
+        path
+      end
+
+      def content_type
+        @filetype
+      end
+    end
+
     YuukiBot.crb.add_command(
       :qr,
       code: proc { |event, args|
@@ -16,11 +44,14 @@ module YuukiBot
           next
         end
 
-        # Force the size to be 512x512 px.
-        qr_code = RQRCode::QRCode.new(content)
-        png = qr_code.as_png(size: 512)
         filename = 'qr.png'
 
+        # Force the size to be 512x512 px.
+        qr_code = RQRCode::QRCode.new(content)
+        png_data = qr_code.as_png(size: 512)
+        qr_file = FauxFile.new png_data.to_blob, filename, 'image/png'
+
+        # Create an embed to wrap the QR code.
         embed = Discordrb::Webhooks::Embed.new
         embed.colour = 0x74f167
         embed.author = Discordrb::Webhooks::EmbedAuthor.new(
@@ -38,52 +69,11 @@ module YuukiBot
           url: "attachment://#{filename}"
         )
 
-        upload_file_with_embed('', embed, png, filename, event.channel.id)
+        attachments = [qr_file]
+        event.channel.send_message('', false, embed, attachments)
       },
       min_args: 1,
       catch_errors: true
     )
-
-    # https://discordapp.com/developers/docs/resources/channel#create-message-using-attachments-within-embeds
-    # @param [String (frozen)] contents The contents of the message being sent
-    # @param [Object] embed The embed attached to this message
-    # @param [Object] file The contents of the file itself.
-    # @param [String (frozen)] The name of the file to present to Discord.
-    # @param [String (frozen)] The ID of this channel to upload to.
-    def self.upload_file_with_embed(contents = '', embed, file, filename, channel_id)
-      # Create an IO stream for our payload information.
-      payload = {
-        content: contents,
-        tts: false,
-        embed: embed.to_hash,
-        nonce: nil
-      }.to_json
-
-      # The default for to_blob is ASCII-8BIT, where we need UTF-8.
-      file_datastream = file.to_datastream
-      file_writer = StringIO.new
-      file_writer.set_encoding('UTF-8')
-      file_datastream.write(file_writer)
-
-      # Route is POST /channels/{channel.id}/messages
-      route = "#{Discordrb::API.api_base}/channels/#{channel_id}/messages"
-      uri = URI.parse(route)
-
-      form_req = Net::HTTP::Post.new(uri)
-      form_req.set_form([
-                          # It's mandatory to set a filename, otherwise the file
-                          # fails to show up without warning.
-                          ['file', file_writer.string, { filename: filename }],
-                          ['payload_json', payload]
-                        ], 'multipart/form-data')
-      # Format: Authorization => Bot <token>
-      form_req['Authorization'] = YuukiBot.crb.bot.token
-
-      n = Net::HTTP.new(uri.host, uri.port)
-      n.use_ssl = true
-      n.start do |http|
-        http.request(form_req)
-      end
-    end
   end
 end


### PR DESCRIPTION
Started off by @spotlightishere's work on the gems, this PR migrates Yuuki to work with and prefer Ruby 3.0 where possible.

I have changed Docker to use the Ruby 3.0 base image, which has the added bonus of allowing us to target `linux/arm/v6` and `linux/arm/v7` where we previously couldn't. Yay for long builds!

I have also added experimental support for pushing to multiple container registries, which should hopefully create `ghcr.io/yuuki-discord/yuuki-bot:latest` to remove the dependency on Docker Hub. That image will be changed to the default in the compose file at a later time once we have it building and pushed successfully.
It also pushes to the deprecated GitHub Packages Docker Registry simply because we already have a package there so we might as well keep it up to date. That feature will be sunsetted by GitHub later in 2021 so shouldn't be relied upon.