### PR TITLE
Add min_args: 1 to 'choose' command, fixes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ You can find a [list of commands on the wiki](https://github.com/yuuki-discord/Y
 
 For Docker (Recommended):
 - A Docker installation, including `docker` and `docker-compose` binaries.
-  - On Debian-based Linux distros this is just a case of `apt install docker docker-compose`
+  - On Debian-based Linux distros this is usually as simple as `apt install docker.io docker-compose` - for advances installations check out [https://docs.docker.com/engine/install](the documentation).
 
 For standalone:
 - Ruby 2.4.0+
 - Bundler (`gem install bundler`)
 - Locally running Redis (`apt install redis-server` ?)
----
 
+Note: We do not currently support running standalone on bare Windows platforms. It should definitely work, but no guarantees or support are made.  
+For Windows it's recommended to use [WSL](https://docs.microsoft.com/en-us/windows/wsl/about) (WSL1 and WSl2 are both fine) or [Docker Desktop](https://docs.docker.com/docker-for-windows/install/).  
+
+
+---
 ## Install and run
 1. Clone the repo: `git clone --recursive https://github.com/yuuki-discord/Yuuki-Bot.git`
 2. cd into the repo: `cd Yuuki-Bot`

--- a/modules/extra/json_cmds.rb
+++ b/modules/extra/json_cmds.rb
@@ -131,13 +131,5 @@ module YuukiBot
       )
       puts 'Added fun command for fight!' if YuukiBot.config['verbose']
     end
-
-    # The choose command does not require extra_commands to be enabled.
-    YuukiBot.crb.add_command(
-      :choose,
-      code: proc { |event, args|
-        event.respond("I choose #{args.sample}!")
-      }
-    )
   end
 end

--- a/modules/utility/say.rb
+++ b/modules/utility/say.rb
@@ -24,5 +24,14 @@ module YuukiBot
       min_args: 1,
       triggers: %w[speak hide]
     )
+
+    # The choose command does not require extra_commands to be enabled.
+    YuukiBot.crb.add_command(
+      :choose,
+      code: proc { |event, args|
+        event.respond("I choose #{args.sample}!")
+      },
+      min_args: 1
+    )
   end
 end


### PR DESCRIPTION
Also moves it to a slightly more appropriate file to get it working with extra commands disabled, see #74 for details.

I assumed that keeping 1 argument as a possibility was more sensible, since the command still does what it says on the tin:
![image](https://user-images.githubusercontent.com/14004943/103485102-f485e100-4deb-11eb-8888-ad5de65f1797.png)
