### PR TITLE
Overhaul devcontainer, upgrade dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,27 @@
 FROM ruby:3.0-buster
-
 WORKDIR /workspace
 
-RUN apt-get update && apt-get install -y --no-install-recommends git build-essential redis-tools openssh-client
+# This Dockerfile contains a lot of "hacky" things, but since it's used for development and not production 
+#  I assume it's fine.
+
+RUN apt-get update && apt-get install -y --no-install-recommends git build-essential redis-tools openssh-client sudo
+
+# For ease of use, convenience more than anything.
 RUN echo "alias redis-cli='redis-cli -h redis'" > /root/.bashrc
 
-CMD ["sleep", "infinity"]
+# For the sake of a pretty prompt, default theme is fine enough.
+RUN bash -c "$(curl -fsSL https://raw.githubusercontent.com/ohmybash/oh-my-bash/master/tools/install.sh)"
+
+# Yay, more scripts from the internet!
+RUN bash -c "$(curl -fsSL https://krypt.co/kr)"
+
+# Stolen from Microsofts image
+ADD https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh  /tmp/library-scripts/
+# Use opensource Docker Engine
+ARG USE_MOBY="true"
+# Install guest Docker
+RUN /bin/bash /tmp/library-scripts/docker-in-docker-debian.sh "false" "root" "${USE_MOBY}"
+
+# Run the guest Docker daemon
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,8 @@
 		"rebornix.ruby"
 	],
 
+	"runArgs": ["--init", "--privileged"],
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services: 
     yuuki:
-        build: .
+        image: yuukibot/devcontainer
         depends_on:
             - redis
         environment:
@@ -11,9 +11,8 @@ services:
         volumes:
             # VSCode workspace mount.
             - ..:/workspace:cached
-        # Make the container run forever in the background so VSCode can attach with ease.
-        entrypoint: sleep
-        command: infinity 
+        # Needed for nested docker
+        privileged: true
     redis:
         image: "redis:alpine"
         volumes:

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -50,7 +50,7 @@ jobs:
         with: 
           context: ./.devcontainer
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             yuukibot/devcontainer:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -35,7 +35,7 @@ jobs:
           username: ${{ secrets.CR_USERNAME }}
           password: ${{ secrets.CR_PAT }}
       -
-        name: Build and push
+        name: Build and push the application
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -45,3 +45,13 @@ jobs:
           tags: |
             yuukibot/yuukichan:latest,
             ghcr.io/yuuki-discord/yuuki-bot:latest,
+      - name: Build and push the devcontainer
+        uses: docker/build-push-action@v2
+        with: 
+          context: ./.devcontainer
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+          yuukibot/devcontainer:latest
+          ghcr.io/yuuki-discord/devcontainer:latest

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -53,5 +53,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-          yuukibot/devcontainer:latest
-          ghcr.io/yuuki-discord/devcontainer:latest
+            yuukibot/devcontainer:latest
+            ghcr.io/yuuki-discord/devcontainer:latest

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -1,12 +1,6 @@
 name: Docker test build (Devcontainer)
 
-on:
-  push:
-    branches: 
-      - "*"
-  pull_request:
-    branches: 
-      - "*"
+on: [push, pull_request]
 
 jobs:
   test-build-dev:

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           context: .
           file: ./.devcontainer/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64
           push: false
           tags: |
             yuukibot/yuukichan:latest

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,12 +1,6 @@
 name: Docker test build
 
-on:
-  push:
-    branches: 
-      - "*"
-  pull_request:
-    branches: 
-      - "*"
+on: [push, pull_request]
 
 jobs:
   test-build-prod:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
     "recommendations": [
         "rebornix.ruby",
         "ms-azuretools.vscode-docker",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "icrawl.discord-vscode"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "name": "Debug Local File",
       "type": "Ruby",
       "request": "launch",
-      "program": "${workspaceRoot}/main.rb"
+      "program": "${workspaceRoot}/main.rb",
+      "useBundler": true
     }
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'http://rubygems.org'
-gem 'commandrb', github: 'Yuuki-Discord/commandrb'
+gem 'commandrb', github: 'Yuuki-Discord/commandrb', branch: 'main'
 gem 'discordrb', github: 'shardlab/discordrb', branch: 'main'
 gem 'haste'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/Yuuki-Discord/commandrb.git
   revision: 688e34b6142c95c0ea28ad36d6176027b1c1696b
+  branch: main
   specs:
     commandrb (0.4.8)
       discordrb (~> 3.1, >= 3.1.0)
@@ -15,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/shardlab/discordrb.git
-  revision: cec5d6854d786dafde25cbd604f52c6c5f452a26
+  revision: e17efe773d6281a22ead831ce7586d98dcdc32af
   branch: main
   specs:
     discordrb (3.4.0)
@@ -28,12 +29,12 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
-    ast (2.4.1)
-    chunky_png (1.3.15)
+    ast (2.4.2)
+    chunky_png (1.4.0)
     coderay (1.1.3)
     debase (0.2.4.1)
       debase-ruby_core_source (>= 0.10.2)
-    debase-ruby_core_source (0.10.11)
+    debase-ruby_core_source (0.10.12)
     discordrb-webhooks (3.3.0)
       rest-client (>= 2.1.0.rc1)
     domain_name (0.5.20190701)
@@ -68,7 +69,7 @@ GEM
     rake (13.0.3)
     rcodetools (0.8.5.0)
     redis (4.2.5)
-    regexp_parser (2.0.2)
+    regexp_parser (2.0.3)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -79,27 +80,27 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.2)
     rqrcode_core (0.2.0)
-    rubocop (1.7.0)
+    rubocop (1.8.1)
       parallel (~> 1.10)
-      parser (>= 2.7.1.5)
+      parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
       rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (1.3.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     rubocop-rake (0.5.1)
       rubocop
     ruby-debug-ide (0.7.2)
       rake (>= 0.8.1)
-    ruby-progressbar (1.10.1)
+    ruby-progressbar (1.11.0)
     rumoji (0.5.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
     websocket (1.2.9)
     websocket-client-simple (0.3.0)
       event_emitter


### PR DESCRIPTION
Closes #64. 
It turns out accessing host Docker is rather complicated and tends to fail when it comes to bind mounts.
Instead we run a nested Docker instance in the devcontainer. This lets ordinary operations like `docker build` and `docker-compose up` work like normal when developing inside a container.
I also added [oh-my-bash](https://github.com/ohmybash/oh-my-bash) so the prompt isn't quite so ugly and `kr` so that I can sign my commits with Krypton.
`kr` is the reason I can't target arm64 for the devcontainer!!

I also started pushing the devcontainer image since it is now getting rather large. It will be on both Docker Hub and GitHub Container Registry - the devcontainer setup currently pulls from Docker Hub because I find myself experiencing slow downloads when using GitHub Container Registry for large images. This can be changed later if the situation improves.
The devcontainer image being this large doesn't concern me too much since it's only used for development.

---

Dependencies also got upgraded, commandrb got changed to `main` branch and somehow we survived a RuboCop upgrade without breaking anything.