### PR TITLE
Specify debase version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rqrcode'
 gem 'rumoji'
 
 group :development, optional: true do
-  gem 'debase'
+  gem 'debase', '~> 0.2.5.beta2'
   gem 'fastri'
   gem 'pry'
   gem 'rcodetools'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,8 +32,8 @@ GEM
     ast (2.4.2)
     chunky_png (1.4.0)
     coderay (1.1.3)
-    debase (0.2.4.1)
-      debase-ruby_core_source (>= 0.10.2)
+    debase (0.2.5.beta2)
+      debase-ruby_core_source (>= 0.10.12)
     debase-ruby_core_source (0.10.12)
     discordrb-webhooks (3.3.0)
       rest-client (>= 2.1.0.rc1)
@@ -111,7 +111,7 @@ PLATFORMS
 
 DEPENDENCIES
   commandrb!
-  debase
+  debase (~> 0.2.5.beta2)
   discordrb!
   fastri
   haste


### PR DESCRIPTION
By specifying, we're able to install the development group under Ruby 3 for Darwin platforms. Once 0.2.5 is released (hopefully soon) this explicit version should be safe to remove.