### PR TITLE
actions: Add caching for Docker layers

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -22,6 +22,14 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
@@ -55,3 +63,5 @@ jobs:
           tags: |
             yuukibot/devcontainer:latest
             ghcr.io/yuuki-discord/devcontainer:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-test-devcontainer.yml
+++ b/.github/workflows/docker-test-devcontainer.yml
@@ -19,6 +19,14 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Build image
         uses: docker/build-push-action@v2
         with:
@@ -28,3 +36,5 @@ jobs:
           push: false
           tags: |
             yuukibot/yuukichan:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -19,6 +19,14 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
         name: Build image
         uses: docker/build-push-action@v2
         with:
@@ -28,3 +36,5 @@ jobs:
           push: false
           tags: |
             yuukibot/yuukichan:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Though their build processes may be different, I tested [with Lykos](https://github.com/Erisa/Lykos/commit/9922100c069c35a3baa2327e845d6b3c22993622) and it brought a [2m30s build](https://github.com/Erisa/Lykos/actions/runs/524243257) down to [34s](https://github.com/Erisa/Lykos/actions/runs/524247538) with [no code changes](https://github.com/Erisa/Lykos/commit/c02758926b0e8e194ad2914a241f876ad4e72e4d).

The benefit may be marginal at times but it should avoid wasted time for frequent commits that change little.