### PR TITLE
Upgrade RuboCop GH Action to Ruby 3.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.0
     - name: Cache gems
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Seems to work, no clue why this wasn't done before.