### PR TITLE
Handle space for love command

### DIFF
--- a/modules/extra/love.rb
+++ b/modules/extra/love.rb
@@ -13,6 +13,11 @@ module YuukiBot
           rescue StandardError
             second = args[0]
           end
+        elsif args.length == 3 && args[1].empty?
+          # Occasionally, Discord clients may insert a space
+          # between two mentions.
+          first = args[0]
+          second = args[2]
         else
           first = args[0]
           second = args[1]


### PR DESCRIPTION
Discord clients can occasionally insert a space after a mention (i.e. `yuuki love person <space> person`), leading to the love command mistakenly detecting the second user as empty.

> :heartpulse: MATCHMAKING :heartpulse:
First - @Snoot 🐾
Second - 

This may be a deeper issue than this fix handles, as the argument is passed as an empty string - perhaps it may be beneficial for commandrb to throw out empty arguments eventually? Happy to open an issue there if it's deemed odd behavior.