### PR TITLE
actions: Bump Docker actions due to Node 12 EOL

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -18,20 +18,20 @@ jobs:
           persist-credentials: false
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: yuuki-discord
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push the application
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
       -
         name: Build image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           builder: builder


### PR DESCRIPTION
The new action versions all use Node 16 rather than Node 12, which is now EOL